### PR TITLE
fix for continue warning inside switch in php 7.3

### DIFF
--- a/lib/Auth/Source/RateLimitUserPass.php
+++ b/lib/Auth/Source/RateLimitUserPass.php
@@ -173,7 +173,7 @@ class RateLimitUserPass extends UserPassBase
                     Logger::stats('User \'' . $username . '\' login attempt blocked by ' . get_class($limiter));
                     return false;
                 case 'continue':
-                    continue;
+                    continue 2;
                 default:
                     Logger::warning("Unrecognized ratelimit allow() value '$result'");
             }


### PR DESCRIPTION
"continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?

https://www.php.net/manual/en/migration73.incompatible.php#migration73.incompatible.core.continue-targeting-switch