### PR TITLE
Fix secure key generation

### DIFF
--- a/lib/Limiters/PasswordStuffingLimiter.php
+++ b/lib/Limiters/PasswordStuffingLimiter.php
@@ -32,7 +32,9 @@ class PasswordStuffingLimiter extends UserPassBaseLimiter
 
     protected function generateSecureKeyFromPassword(string $password): string
     {
-        $cryptoUtils = new Utils\Crypto();
-        return base64_encode($cryptoUtils->pwHash($password));
+        $configUtils = new Utils\Config();
+        $salt = $configUtils->getSecretSalt();
+
+        return base64_encode(crypt($password, $salt));
     }
 }

--- a/lib/Limiters/PasswordStuffingLimiter.php
+++ b/lib/Limiters/PasswordStuffingLimiter.php
@@ -33,14 +33,7 @@ class PasswordStuffingLimiter extends UserPassBaseLimiter
 
     protected function generateSecureKeyFromPassword(string $password)
     {
-        $configUtils = new Config();
-
-        $salt = '' . $this->determineWindowExpiration(time()) . $configUtils->getSecretSalt();
-        // Configure salt to use bcrypt
-        $cryptSalt = sprintf('$2a$%02d$', $this->cost) . $salt;
-        $hash = crypt($password, $cryptSalt);
-        // Remove the salt, and only use part of the hash out of paranoia
-        $key = substr($hash, strlen($cryptSalt), 25);
-        return $key;
+        $cryptoUtils = new Utils\Crypto();
+        return base64_encode($cryptoUtils->pwHash($password));
     }
 }

--- a/lib/Limiters/PasswordStuffingLimiter.php
+++ b/lib/Limiters/PasswordStuffingLimiter.php
@@ -2,9 +2,8 @@
 
 namespace SimpleSAML\Module\ratelimit\Limiters;
 
-use SAML2\Utils;
 use SimpleSAML\Configuration;
-use SimpleSAML\Utils;
+use SimpleSAML\Utils\Crypto;
 
 /**
  * Prevent password stuffing attacks by blocking repeated attempts on an incorrect password.

--- a/lib/Limiters/PasswordStuffingLimiter.php
+++ b/lib/Limiters/PasswordStuffingLimiter.php
@@ -4,7 +4,7 @@ namespace SimpleSAML\Module\ratelimit\Limiters;
 
 use SAML2\Utils;
 use SimpleSAML\Configuration;
-use SimpleSAML\Utils\Config;
+use SimpleSAML\Utils;
 
 /**
  * Prevent password stuffing attacks by blocking repeated attempts on an incorrect password.

--- a/lib/Limiters/PasswordStuffingLimiter.php
+++ b/lib/Limiters/PasswordStuffingLimiter.php
@@ -31,7 +31,7 @@ class PasswordStuffingLimiter extends UserPassBaseLimiter
         return 'password-' . $this->generateSecureKeyFromPassword($password);
     }
 
-    protected function generateSecureKeyFromPassword(string $password)
+    protected function generateSecureKeyFromPassword(string $password): string
     {
         $cryptoUtils = new Utils\Crypto();
         return base64_encode($cryptoUtils->pwHash($password));


### PR DESCRIPTION
Closes #10

I think it makes sense to just use the entire hash.. I added base64 encoding because not every store backend may work with keys containing `$` and `.`..