### PR TITLE
Set allow-plugins tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,9 @@
         "phpunit/phpunit": "^8.5",
         "cirrusidentity/simplesamlphp-test-utils": "dev-master",
         "squizlabs/php_codesniffer": "^3.5"
+    },
+    "allow-plugins": {
+        "composer/package-versions-deprecated": true,
+        "simplesamlphp/composer-module-installer": true
     }
 }


### PR DESCRIPTION
For additional security you should declare the allow-plugins config with a list of packages names that are allowed to run code. See https://getcomposer.org/allow-plugins You have until July 2022 to add the setting. Composer will then switch the default behavior to disallow all plugins.