### PR TITLE
Update module to stay compatible with SimpleSAMLphp and PHP 8.3+

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -88,7 +88,6 @@ jobs:
         run: phpcs
 
       - name: Psalm
-        continue-on-error: true
         run: |
           psalm -c psalm.xml \
           --show-info=true \
@@ -96,6 +95,7 @@ jobs:
           --php-version=${{ steps.setup-php.outputs.php-version }}
 
       - name: Psalm (testsuite)
+        continue-on-error: true
         run: |
           psalm -c psalm-dev.xml \
           --show-info=true \

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,50 +1,72 @@
+---
+
 name: CI
 
-on: [push, pull_request]
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: ['**']
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    branches: [master, release-*]
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
 
 jobs:
-  basic-tests:
-    name: Syntax and unit tests, PHP ${{ matrix.php-versions }}, ${{ matrix.operating-system }}
-    runs-on: ${{ matrix.operating-system }}
-    strategy:
-      fail-fast: false
-      matrix:
-        operating-system: [ubuntu-latest, windows-latest]
-        php-versions: ['7.4', '8.0', '8.1', '8.2']
+  linter:
+    name: Linter
+    runs-on: ['ubuntu-latest']
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # super-linter needs the full git history to get the
+          # list of files that changed across commits
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        uses: super-linter/super-linter/slim@v6
+        env:
+          # To report GitHub Actions status checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINTER_RULES_PATH: 'tools/linters'
+          LOG_LEVEL: NOTICE
+          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_CSS: true
+          VALIDATE_JAVASCRIPT_ES: true
+          VALIDATE_JSON: true
+          VALIDATE_PHP_BUILTIN: true
+          VALIDATE_YAML: true
+          VALIDATE_XML: true
+          VALIDATE_GITHUB_ACTIONS: true
+
+  quality:
+    name: Quality control
+    runs-on: [ubuntu-latest]
 
     steps:
       - name: Setup PHP, with composer and extensions
-        uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+        id: setup-php
+        # https://github.com/shivammathur/setup-php
+        uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
-          extensions: intl, mbstring, mysql, pdo, pdo_sqlite, xml
-          tools: composer:v2
-          ini-values: error_reporting=E_ALL
-          coverage: pcov
+          # Should be the higest supported version, so we can use the newest tools
+          php-version: '8.3'
+          tools: composer, composer-require-checker, composer-unused, phpcs, psalm
+          # optional performance gain for psalm: opcache
+          extensions: ctype, date, dom, fileinfo, filter, hash, intl, mbstring, opcache, openssl, pcre, posix, spl, xml
 
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
 
-      - name: Setup problem matchers for PHPUnit
-        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+      - uses: actions/checkout@v4
 
-      - name: Set git to use LF
-        run: |
-          git config --global core.autocrlf false
-          git config --global core.eol lf
-
-      - uses: actions/checkout@v3
-
-      - name: Get composer cache directory (linux)
-        if: ${{ matrix.operating-system == 'ubuntu-latest' }}
-        run: echo "COMPOSER_CACHE=$(composer config cache-files-dir)" >> $GITHUB_ENV
-
-      - name: Get composer cache directory (windows)
-        if: ${{ matrix.operating-system == 'windows-latest' }}
-        run: echo "COMPOSER_CACHE=$(composer config cache-files-dir)" >> $env:GITHUB_ENV
+      - name: Get composer cache directory
+        run: echo COMPOSER_CACHE="$(composer config cache-files-dir)" >> "$GITHUB_ENV"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: $COMPOSER_CACHE
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -56,44 +78,61 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
-      - name: Syntax check PHP
-        run: bash vendor/bin/check-syntax-php.sh
+      - name: Check code for hard dependencies missing in composer.json
+        run: composer-require-checker check --config-file=tools/composer-require-checker.json composer.json
 
-      - name: Decide whether to run code coverage or not
-        if: ${{ matrix.php-versions != '7.4' || matrix.operating-system != 'ubuntu-latest' }}
+      - name: Check code for unused dependencies in composer.json
+        run: composer-unused
+
+      - name: PHP Code Sniffer
+        run: phpcs
+
+      - name: Psalm
+        continue-on-error: true
         run: |
-          echo "NO_COVERAGE=--no-coverage" >> $GITHUB_ENV
+          psalm -c psalm.xml \
+          --show-info=true \
+          --shepherd \
+          --php-version=${{ steps.setup-php.outputs.php-version }}
 
-      - name: Run unit tests
+      - name: Psalm (testsuite)
         run: |
-          ./vendor/bin/phpunit ${{ env.NO_COVERAGE }}
+          psalm -c psalm-dev.xml \
+          --show-info=true \
+          --shepherd \
+          --php-version=${{ steps.setup-php.outputs.php-version }}
 
-      - name: Save coverage data
-        if: ${{ matrix.php-versions == '7.4' && matrix.operating-system == 'ubuntu-latest' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: build-data
-          path: ${{ github.workspace }}/build
+      - name: Psalter
+        run: |
+          psalm --alter \
+          --issues=UnnecessaryVarAnnotation \
+          --dry-run \
+          --php-version=${{ steps.setup-php.outputs.php-version }}
 
   security:
     name: Security checks
-    runs-on: [ ubuntu-latest ]
+    runs-on: [ubuntu-latest]
     steps:
       - name: Setup PHP, with composer and extensions
-        uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+        # https://github.com/shivammathur/setup-php
+        uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
-          extensions: mbstring, xml
-          tools: composer:v2
+          # Should be the lowest supported version
+          php-version: '8.1'
+          extensions: ctype, date, dom, fileinfo, filter, hash, intl, mbstring, openssl, pcre, posix, spl, xml
+          tools: composer
           coverage: none
 
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - name: Get composer cache directory
+        run: echo COMPOSER_CACHE="$(composer config cache-files-dir)" >> "$GITHUB_ENV"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: $COMPOSER_CACHE
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -111,49 +150,147 @@ jobs:
       - name: Security check for updated dependencies
         run: composer audit
 
-  quality:
-    name: Quality control
-    runs-on: [ ubuntu-latest ]
-    needs: [ basic-tests ]
+  unit-tests-linux:
+    name: "Unit tests, PHP ${{ matrix.php-versions }}, ${{ matrix.operating-system }}"
+    runs-on: ${{ matrix.operating-system }}
+    needs: [linter, quality, security]
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['8.1', '8.2', '8.3']
 
     steps:
       - name: Setup PHP, with composer and extensions
-        id: setup-php
-        uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+        # https://github.com/shivammathur/setup-php
+        uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
-          tools: composer:v2
-          extensions: mbstring, xml
-          coverage: none
+          php-version: ${{ matrix.php-versions }}
+          extensions: ctype, date, dom, fileinfo, filter, hash, intl, mbstring, openssl, pcre, posix, spl, xml
+          tools: composer
+          ini-values: error_reporting=E_ALL
+          coverage: pcov
 
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
 
-      - uses: actions/checkout@v3
+      - name: Setup problem matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - uses: actions/checkout@v4
+
+      - name: Get composer cache directory
+        run: echo COMPOSER_CACHE="$(composer config cache-files-dir)" >> "$GITHUB_ENV"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
-          path: COMPOSER_CACHE
+          path: $COMPOSER_CACHE
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install Composer dependencies
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
-      - uses: actions/download-artifact@v3
+      - name: Run unit tests with coverage
+        if: ${{ matrix.php-versions == '8.3' }}
+        run: vendor/bin/phpunit
+
+      - name: Run unit tests (no coverage)
+        if: ${{ matrix.php-versions != '8.3' }}
+        run: vendor/bin/phpunit --no-coverage
+
+      - name: Save coverage data
+        if: ${{ matrix.php-versions == '8.3' }}
+        uses: actions/upload-artifact@v4
         with:
-          name: build-data
+          name: coverage-data
+          path: ${{ github.workspace }}/build
+
+  unit-tests-windows:
+    name: "Unit tests, PHP ${{ matrix.php-versions }}, ${{ matrix.operating-system }}"
+    runs-on: ${{ matrix.operating-system }}
+    needs: [linter, quality, security]
+    strategy:
+      fail-fast: true
+      matrix:
+        operating-system: [windows-latest]
+        php-versions: ['8.1', '8.2', '8.3']
+
+    steps:
+      - name: Setup PHP, with composer and extensions
+        # https://github.com/shivammathur/setup-php
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: ctype, date, dom, fileinfo, filter, hash, intl, mbstring, openssl, pcre, posix, spl, xml
+          tools: composer
+          ini-values: error_reporting=E_ALL
+          coverage: none
+
+      - name: Setup problem matchers for PHP
+        run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+
+      - name: Setup problem matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - uses: actions/checkout@v4
+
+      - name: Get composer cache directory
+        run: echo COMPOSER_CACHE="$(composer config cache-files-dir)" >> "$env:GITHUB_ENV"
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: $COMPOSER_CACHE
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install Composer dependencies
+        run: composer install --no-progress --prefer-dist --optimize-autoloader --ignore-platform-req=ext-posix
+
+      - name: Run unit tests
+        run: vendor/bin/phpunit --no-coverage
+
+  coverage:
+    name: Code coverage
+    runs-on: [ubuntu-latest]
+    needs: [unit-tests-linux]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage-data
           path: ${{ github.workspace }}/build
 
       - name: Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          verbose: true
 
-      - name: PHP Code Sniffer
-        run: php vendor/bin/phpcs
+  cleanup:
+    name: Cleanup artifacts
+    needs: [unit-tests-linux, coverage]
+    runs-on: [ubuntu-latest]
+    if: |
+      always() &&
+      needs.coverage.result == 'success' ||
+      (needs.unit-tests-linux == 'success' && needs.coverage == 'skipped')
 
-      - name: Psalm
-        run: php vendor/bin/psalm --show-info=true --shepherd --php-version=${{ steps.setup-php.outputs.php-version }}
-
-      - name: Psalter
-        run: php vendor/bin/psalter --issues=UnnecessaryVarAnnotation --dry-run --php-version=${{ steps.setup-php.outputs.php-version }}
+    steps:
+      - uses: geekyeggo/delete-artifact@v5
+        with:
+          name: coverage-data

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ vendor/
 *~
 .idea/
 .DS_Store
+.phpunit.cache/
 .phpunit.result.cache
 /modules/
 /tests/tmp

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,10 @@
     "description": "Ratelimit certain actions, such as username + password login",
     "type": "simplesamlphp-module",
     "require": {
-        "php": ">=7.4 || ^8.0",
-        "simplesamlphp/composer-module-installer": "~1.1",
-        "simplesamlphp/simplesamlphp": "^v2.0.0"
+        "php": "^8.1",
+
+        "simplesamlphp/composer-module-installer": "~1.3.4",
+        "simplesamlphp/simplesamlphp": "^2.2.0"
     },
     "autoload": {
         "psr-4": {
@@ -14,18 +15,19 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "SimpleSAML\\Test\\Module\\ratelimit\\": "tests/src"
+            "SimpleSAML\\Test\\Module\\ratelimit\\": "tests/src",
+            "SimpleSAML\\Test\\Module\\ratelimit\\Utils\\": "tests/Utils"
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
         "cirrusidentity/simplesamlphp-test-utils": "v2.x-dev",
-        "simplesamlphp/simplesamlphp-test-framework": "~1.2.1"
+        "simplesamlphp/simplesamlphp-test-framework": "~1.7"
     },
     "config": {
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
-            "simplesamlphp/composer-module-installer": true
+            "simplesamlphp/composer-module-installer": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": "^8.1",
         "ext-openssl": "*",
 
-        "simplesamlphp/assert": "~1.1.6",
+        "simplesamlphp/assert": "~1.1.3",
         "simplesamlphp/composer-module-installer": "~1.3.4",
         "simplesamlphp/simplesamlphp": "^2.2.0",
         "symfony/http-foundation": "^6.4"
@@ -23,7 +23,6 @@
         }
     },
     "require-dev": {
-        "cirrusidentity/simplesamlphp-test-utils": "v2.x-dev",
         "simplesamlphp/simplesamlphp-test-framework": "~1.7"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,12 @@
     "type": "simplesamlphp-module",
     "require": {
         "php": "^8.1",
+        "ext-openssl": "*",
 
+        "simplesamlphp/assert": "~1.1.6",
         "simplesamlphp/composer-module-installer": "~1.3.4",
-        "simplesamlphp/simplesamlphp": "^2.2.0"
+        "simplesamlphp/simplesamlphp": "^2.2.0",
+        "symfony/http-foundation": "^6.4"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">./lib</directory>
-    </include>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.1/phpunit.xsd" cacheDirectory=".phpunit.cache">
+  <coverage>
     <report>
       <clover outputFile="build/logs/clover.xml"/>
       <html outputDirectory="build/coverage" lowUpperBound="35" highLowerBound="70"/>
@@ -13,7 +10,12 @@
   <testsuites>
     <testsuite name="The project's test suite">
       <directory>./vendor/simplesamlphp/simplesamlphp-test-framework/src</directory>
-      <directory>./tests</directory>
+      <directory>./tests/src</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./lib</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,7 +15,7 @@
   </testsuites>
   <source>
     <include>
-      <directory suffix=".php">./lib</directory>
+      <directory suffix=".php">./src</directory>
     </include>
   </source>
 </phpunit>

--- a/psalm-dev.xml
+++ b/psalm-dev.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<psalm
+    name="SimpleSAMLphp testsuite"
+    useDocblockTypes="true"
+    errorLevel="4"
+    reportMixedIssues="false"
+    hideExternalErrors="true"
+    allowStringToStandInForClass="true"
+>
+    <projectFiles>
+        <directory name="tests" />
+
+        <!-- Ignore certain directories -->
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <!-- Ignore UnresolvableInclude on CLI-scripts -->
+        <UnresolvableInclude>
+            <errorLevel type="suppress">
+                <file name="tests/bootstrap.php" />
+            </errorLevel>
+        </UnresolvableInclude>
+    </issueHandlers>
+</psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -19,7 +19,9 @@
             <directory name="tests/docker" />
         </ignoreFiles>
     </projectFiles>
+
     <issueHandlers>
         <PropertyNotSetInConstructor errorLevel="info" />
+        <MissingClassConstType errorLevel="suppress" />
     </issueHandlers>
 </psalm>

--- a/src/Auth/Source/RateLimitUserPass.php
+++ b/src/Auth/Source/RateLimitUserPass.php
@@ -1,22 +1,30 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimpleSAML\Module\ratelimit\Auth\Source;
 
+use Exception;
 use ReflectionClass;
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\Auth\Source;
-use SimpleSAML\Configuration;
+use SimpleSAML\{Configuration, Logger, Module};
 use SimpleSAML\Error\Error;
-use SimpleSAML\Logger;
-use SimpleSAML\Module;
 use SimpleSAML\Module\core\Auth\UserPassBase;
-use SimpleSAML\Module\ratelimit\Limiters\DeviceCookieLimiter;
-use SimpleSAML\Module\ratelimit\Limiters\IpLimiter;
-use SimpleSAML\Module\ratelimit\Limiters\PasswordStuffingLimiter;
-use SimpleSAML\Module\ratelimit\Limiters\UsernameLimiter;
-use SimpleSAML\Module\ratelimit\Limiters\UserPassLimiter;
-use SimpleSAML\Store\StoreFactory;
-use SimpleSAML\Store\StoreInterface;
+use SimpleSAML\Module\ratelimit\Limiters\{
+    DeviceCookieLimiter,
+    IpLimiter,
+    PasswordStuffingLimiter,
+    UsernameLimiter,
+    UserPassLimiter,
+};
+use SimpleSAML\Store\{StoreFactory, StoreInterface};
+
+use function get_class;
+use function is_string;
+use function microtime;
+use function sprintf;
+use function var_export;
 
 /**
  * Auth source that rate limits user and password attempts
@@ -96,7 +104,7 @@ class RateLimitUserPass extends UserPassBase
             /** @var UserPassBase */
             $authInstance = $method->invokeArgs(null, [$this->getAuthId() . '-delegate', $delegate]);
         } else {
-            throw new \Exception('Invalid configuration for delegate. Must be string or array');
+            throw new Exception('Invalid configuration for delegate. Must be string or array');
         }
         Assert::isInstanceOf($authInstance, UserPassBase::class);
         return $authInstance;
@@ -188,16 +196,20 @@ class RateLimitUserPass extends UserPassBase
         foreach ($this->rateLimiters as $limiter) {
             try {
                 $result = $limiter->allow($username, $password);
-            } catch (\Exception $e) {
-                Logger::warning('Limiter error in \'allow\' of ' . get_class($limiter) . ' Error ' . $e->getMessage());
+            } catch (Exception $e) {
+                Logger::warning(sprintf(
+                    'Limiter error in \'allow\' of %s; Error %s',
+                    get_class($limiter),
+                    $e->getMessage(),
+                ));
                 continue;
             }
             switch ($result) {
                 case 'allow':
-                    Logger::debug('User \'' . $username . '\' login attempt allowed by ' . get_class($limiter));
+                    Logger::debug(sprintf('User \'%s\' login attempt allowed by %s', $username, get_class($limiter)));
                     return true;
                 case 'block':
-                    Logger::stats('User \'' . $username . '\' login attempt blocked by ' . get_class($limiter));
+                    Logger::stats(sprintf('User \'%s\' login attempt blocked by %s', $username, get_class($limiter)));
                     return false;
                 case 'continue':
                     continue 2;
@@ -220,10 +232,12 @@ class RateLimitUserPass extends UserPassBase
         foreach ($this->rateLimiters as $limiter) {
             try {
                 $limiter->postFailure($username, $password);
-            } catch (\Exception $e) {
-                Logger::warning(
-                    'Limiter error in \'postFailure\' of ' . get_class($limiter) . ' Error ' . $e->getMessage()
-                );
+            } catch (Exception $e) {
+                Logger::warning(sprintf(
+                    'Limiter error in \'postFailure\' of %s; Error %s',
+                    get_class($limiter),
+                    $e->getMessage(),
+                ));
                 continue;
             }
         }
@@ -240,10 +254,12 @@ class RateLimitUserPass extends UserPassBase
         foreach ($this->rateLimiters as $limiter) {
             try {
                 $limiter->postSuccess($username, $password);
-            } catch (\Exception $e) {
-                Logger::warning(
-                    'Limiter error in \'postSuccess\' of ' . get_class($limiter) . ' Error ' . $e->getMessage()
-                );
+            } catch (Exception $e) {
+                Logger::warning(sprintf(
+                    'Limiter error in \'postSuccess\' of %s; Error %s',
+                    get_class($limiter),
+                    $e->getMessage(),
+                ));
                 continue;
             }
         }

--- a/src/Auth/Source/RateLimitUserPass.php
+++ b/src/Auth/Source/RateLimitUserPass.php
@@ -33,15 +33,16 @@ use function var_export;
 class RateLimitUserPass extends UserPassBase
 {
     /**
-     * @var UserPassBase The auth source to handle the login
+     * @var \SimpleSAML\Module\core\Auth\UserPassBase The auth source to handle the login
      */
     private UserPassBase $delegate;
 
     /**
-     * @var UserPassLimiter[]
+     * @var \SimpleSAML\Module\ratelimit\Limiters\UserPassLimiter[]
      */
     private array $rateLimiters = [];
 
+    /** @psalm-suppress MissingClassConstType */
     private const DEFAULT_CONFIG = [
         0 => [
             'device',
@@ -89,19 +90,20 @@ class RateLimitUserPass extends UserPassBase
 
     /**
      * @param mixed $delegate
-     * @return UserPassBase
+     * @return \SimpleSAML\Module\core\Auth\UserPassBase
      */
     private function resolveDelegateConfig($delegate): UserPassBase
     {
         if (is_string($delegate)) {
             // delegate to another named authsource
-            /** @var UserPassBase */
+            /** @var \SimpleSAML\Module\core\Auth\UserPassBase */
             $authInstance = Source::getById($delegate, UserPassBase::class);
         } elseif (is_array($delegate)) {
             $class = new ReflectionClass(Source::class);
             $method = $class->getMethod('parseAuthSource');
+            /** @psalm-suppress UnusedMethodCall */
             $method->setAccessible(true);
-            /** @var UserPassBase */
+            /** @var \SimpleSAML\Module\core\Auth\UserPassBase */
             $authInstance = $method->invokeArgs(null, [$this->getAuthId() . '-delegate', $delegate]);
         } else {
             throw new Exception('Invalid configuration for delegate. Must be string or array');

--- a/src/Auth/Source/RateLimitUserPass.php
+++ b/src/Auth/Source/RateLimitUserPass.php
@@ -18,6 +18,7 @@ use SimpleSAML\Module\ratelimit\Limiters\{
     UsernameLimiter,
     UserPassLimiter,
 };
+use SimpleSAML\Module\ratelimit\PreAuthStatusEnum;
 use SimpleSAML\Store\{StoreFactory, StoreInterface};
 
 use function get_class;
@@ -42,7 +43,10 @@ class RateLimitUserPass extends UserPassBase
      */
     private array $rateLimiters = [];
 
-    /** @psalm-suppress MissingClassConstType */
+    /**
+     * @var array
+     * psalm-suppress MissingClassConstType
+     */
     private const DEFAULT_CONFIG = [
         0 => [
             'device',
@@ -207,16 +211,14 @@ class RateLimitUserPass extends UserPassBase
                 continue;
             }
             switch ($result) {
-                case 'allow':
+                case PreAuthStatusEnum::ALLOW:
                     Logger::debug(sprintf('User \'%s\' login attempt allowed by %s', $username, get_class($limiter)));
                     return true;
-                case 'block':
+                case PreAuthStatusEnum::BLOCK:
                     Logger::stats(sprintf('User \'%s\' login attempt blocked by %s', $username, get_class($limiter)));
                     return false;
-                case 'continue':
+                case PreAuthStatusEnum::CONTINUE:
                     continue 2;
-                default:
-                    Logger::warning("Unrecognized ratelimit allow() value '$result'");
             }
         }
 

--- a/src/Controller/RateLimit.php
+++ b/src/Controller/RateLimit.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimpleSAML\Module\ratelimit\Controller;
 
 use SimpleSAML\Auth\ProcessingChain;

--- a/src/Limiters/DeviceCookieLimiter.php
+++ b/src/Limiters/DeviceCookieLimiter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Module\ratelimit\Limiters;
 
 use SimpleSAML\{Configuration, Logger};
+use SimpleSAML\Module\ratelimit\PreAuthStatusEnum;
 use SimpleSAML\Utils\HTTP;
 
 use function sprintf;
@@ -31,18 +32,18 @@ class DeviceCookieLimiter extends UserPassBaseLimiter
         return "device-" . $this->checkForDeviceCookie();
     }
 
-    public function allow(string $username, string $password): string
+    public function allow(string $username, string $password): PreAuthStatusEnum
     {
         if (!$this->hasDeviceCookieSet()) {
-            return UserPassBaseLimiter::PREAUTH_CONTINUE;
+            return PreAuthStatusEnum::CONTINUE;
         }
         $key = $this->getRateLimitKey($username, $password);
         /** @var array|null $ret */
         $ret = $this->getStore()->get('array', "ratelimit-$key");
         if ($ret === null) {
-            return UserPassBaseLimiter::PREAUTH_CONTINUE;
+            return PreAuthStatusEnum::CONTINUE;
         }
-        return $ret['user'] === $username ? UserPassBaseLimiter::PREAUTH_ALLOW : UserPassBaseLimiter::PREAUTH_CONTINUE;
+        return $ret['user'] === $username ? PreAuthStatusEnum::ALLOW : PreAuthStatusEnum::CONTINUE;
     }
 
     public function postFailure(string $username, string $password): int

--- a/src/Limiters/DeviceCookieLimiter.php
+++ b/src/Limiters/DeviceCookieLimiter.php
@@ -1,10 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimpleSAML\Module\ratelimit\Limiters;
 
-use SimpleSAML\Configuration;
-use SimpleSAML\Logger;
+use SimpleSAML\{Configuration, Logger};
 use SimpleSAML\Utils\HTTP;
+
+use function sprintf;
+use function time;
 
 class DeviceCookieLimiter extends UserPassBaseLimiter
 {
@@ -57,7 +61,10 @@ class DeviceCookieLimiter extends UserPassBaseLimiter
         // Only track attempts for device cookies that exist and match the user
         $ret['count']++;
         if ($ret['count'] >= $this->limit) {
-            Logger::debug('Too many failed attempts for device cookie \'' . $this->checkForDeviceCookie() . '\'');
+            Logger::debug(sprintf(
+                'Too many failed attempts for device cookie \'%s\'',
+                $this->checkForDeviceCookie(),
+            ));
             $store->delete('array', "ratelimit-$key");
             $this->setDeviceCookie(null);
         } else {
@@ -94,7 +101,7 @@ class DeviceCookieLimiter extends UserPassBaseLimiter
         $params = array(
             'lifetime' => $this->window,
             'path' => Configuration::getConfig()->getBasePath(),
-            'secure'   => Configuration::getConfig()->getOptionalBoolean('session.cookie.secure', false),
+            'secure' => Configuration::getConfig()->getOptionalBoolean('session.cookie.secure', false),
         );
 
         $this->getHttp()->setCookie(

--- a/src/Limiters/IpLimiter.php
+++ b/src/Limiters/IpLimiter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Module\ratelimit\Limiters;
 
 use SimpleSAML\{Configuration, Logger};
+use SimpleSAML\Module\ratelimit\PreAuthStatusEnum;
 use Symfony\Component\HttpFoundation\{IpUtils, Request};
 
 /**
@@ -32,10 +33,10 @@ class IpLimiter extends UserPassBaseLimiter
         $this->clientIpAddress = $ip;
     }
 
-    public function allow(string $username, string $password): string
+    public function allow(string $username, string $password): PreAuthStatusEnum
     {
         if ($this->isIpWhiteListed($this->clientIpAddress)) {
-            return UserPassBaseLimiter::PREAUTH_CONTINUE;
+            return PreAuthStatusEnum::CONTINUE;
         }
         return parent::allow($username, $password);
     }

--- a/src/Limiters/IpLimiter.php
+++ b/src/Limiters/IpLimiter.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimpleSAML\Module\ratelimit\Limiters;
 
-use SimpleSAML\Configuration;
-use SimpleSAML\Logger;
-use Symfony\Component\HttpFoundation\IpUtils;
-use Symfony\Component\HttpFoundation\Request;
+use SimpleSAML\{Configuration, Logger};
+use Symfony\Component\HttpFoundation\{IpUtils, Request};
 
 /**
  * Limit attempts by IP address
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
 class IpLimiter extends UserPassBaseLimiter
 {
     /**
-     * @var array The IP addresses that we ignore the rate limiter for
+     * @var string[] The IP addresses that we ignore the rate limiter for
      */
     private array $whitelist;
 
@@ -23,7 +23,6 @@ class IpLimiter extends UserPassBaseLimiter
     public function __construct(Configuration $config)
     {
         parent::__construct($config);
-        /** @var string[] whitelist */
         $this->whitelist = $config->getOptionalArray('whitelist', []);
         $ip = Request::createFromGlobals()->getClientIp();
         if ($ip == null) {

--- a/src/Limiters/IpLimiter.php
+++ b/src/Limiters/IpLimiter.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\{IpUtils, Request};
 class IpLimiter extends UserPassBaseLimiter
 {
     /**
-     * @var string[] The IP addresses that we ignore the rate limiter for
+     * @var array<mixed> The IP addresses that we ignore the rate limiter for
      */
     private array $whitelist;
 

--- a/src/Limiters/PasswordStuffingLimiter.php
+++ b/src/Limiters/PasswordStuffingLimiter.php
@@ -9,7 +9,6 @@ use SimpleSAML\Assert\Assert;
 use SimpleSAML\{Configuration, Logger};
 use SimpleSAML\Utils\Config;
 
-use function base64_decode;
 use function crypt;
 use function sprintf;
 use function strlen;

--- a/src/Limiters/PasswordStuffingLimiter.php
+++ b/src/Limiters/PasswordStuffingLimiter.php
@@ -1,11 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimpleSAML\Module\ratelimit\Limiters;
 
+use RuntimeException;
 use SimpleSAML\Assert\Assert;
-use SimpleSAML\Configuration;
-use SimpleSAML\Logger;
+use SimpleSAML\{Configuration, Logger};
 use SimpleSAML\Utils\Config;
+
+use function base64_decode;
+use function crypt;
+use function sprintf;
+use function strlen;
+use function substr;
+use function time;
 
 /**
  * Prevent password stuffing attacks by blocking repeated attempts on an incorrect password.
@@ -54,7 +63,7 @@ class PasswordStuffingLimiter extends UserPassBaseLimiter
          * the salt on failure.'. Failure reasons can include a salt with special characters or a small salt.
          */
         if (strlen($hash) < 13) {
-            throw new \RuntimeException('Unable to generate password hash key');
+            throw new RuntimeException('Unable to generate password hash key');
         }
 
 

--- a/src/Limiters/UserPassBaseLimiter.php
+++ b/src/Limiters/UserPassBaseLimiter.php
@@ -14,8 +14,13 @@ use function intval;
 
 abstract class UserPassBaseLimiter implements UserPassLimiter
 {
+    /** @psalm-suppress MissingClassConstType */
     protected const PREAUTH_ALLOW = 'allow';
+
+    /** @psalm-suppress MissingClassConstType */
     protected const PREAUTH_BLOCK = 'block';
+
+    /** @psalm-suppress MissingClassConstType */
     protected const PREAUTH_CONTINUE = 'continue';
 
     /**
@@ -115,6 +120,7 @@ abstract class UserPassBaseLimiter implements UserPassLimiter
         $storeType = $config->getOptionalString('store.type', 'phpsession');
         $store = StoreFactory::getInstance($storeType);
         Assert::notFalse($store, "Store must be configured");
+        /** @psalm-var \SimpleSAML\Store\StoreInterface $store */
         return $store;
     }
 

--- a/src/Limiters/UserPassBaseLimiter.php
+++ b/src/Limiters/UserPassBaseLimiter.php
@@ -6,6 +6,7 @@ namespace SimpleSAML\Module\ratelimit\Limiters;
 
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\Configuration;
+use SimpleSAML\Module\ratelimit\PreAuthStatusEnum;
 use SimpleSAML\Store\{StoreFactory, StoreInterface};
 use SimpleSAML\Utils\Time;
 
@@ -14,15 +15,6 @@ use function intval;
 
 abstract class UserPassBaseLimiter implements UserPassLimiter
 {
-    /** @psalm-suppress MissingClassConstType */
-    protected const PREAUTH_ALLOW = 'allow';
-
-    /** @psalm-suppress MissingClassConstType */
-    protected const PREAUTH_BLOCK = 'block';
-
-    /** @psalm-suppress MissingClassConstType */
-    protected const PREAUTH_CONTINUE = 'continue';
-
     /**
      * @var int $limit The limit of attempts
      */
@@ -54,16 +46,16 @@ abstract class UserPassBaseLimiter implements UserPassLimiter
      * Called prior to verifying the credentials to determine if the attempt is allowed.
      * @param string $username The username to check
      * @param string $password The password to check
-     * @return string allow|block|continue
+     * @return \SimpleSAML\Module\ratelimit\PreAuthStatusEnum
      */
-    public function allow(string $username, string $password): string
+    public function allow(string $username, string $password): PreAuthStatusEnum
     {
         $key = $this->getRateLimitKey($username, $password);
         $count = $this->getCurrentCount($key);
         if ($count >= $this->limit) {
-            return UserPassBaseLimiter::PREAUTH_BLOCK;
+            return PreAuthStatusEnum::BLOCK;
         }
-        return UserPassBaseLimiter::PREAUTH_CONTINUE;
+        return PreAuthStatusEnum::CONTINUE;
     }
 
     /**

--- a/src/Limiters/UserPassBaseLimiter.php
+++ b/src/Limiters/UserPassBaseLimiter.php
@@ -1,12 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimpleSAML\Module\ratelimit\Limiters;
 
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\Configuration;
-use SimpleSAML\Store\StoreFactory;
-use SimpleSAML\Store\StoreInterface;
+use SimpleSAML\Store\{StoreFactory, StoreInterface};
 use SimpleSAML\Utils\Time;
+
+use function ceil;
+use function intval;
 
 abstract class UserPassBaseLimiter implements UserPassLimiter
 {
@@ -110,7 +114,7 @@ abstract class UserPassBaseLimiter implements UserPassLimiter
         $config = Configuration::getInstance();
         $storeType = $config->getOptionalString('store.type', 'phpsession');
         $store = StoreFactory::getInstance($storeType);
-        assert($store !== false, "Store must be configured");
+        Assert::notFalse($store, "Store must be configured");
         return $store;
     }
 

--- a/src/Limiters/UserPassLimiter.php
+++ b/src/Limiters/UserPassLimiter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimpleSAML\Module\ratelimit\Limiters;
 
 /**

--- a/src/Limiters/UserPassLimiter.php
+++ b/src/Limiters/UserPassLimiter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\ratelimit\Limiters;
 
+use SimpleSAML\Module\ratelimit\PreAuthStatusEnum;
+
 /**
  * Allow limiting of user password authentications
  * @package SimpleSAML\Module\ratelimit
@@ -14,9 +16,9 @@ interface UserPassLimiter
      * Called prior to verifying the credentials to determine if the attempt is allowed.
      * @param string $username The username to check
      * @param string $password The password to check
-     * @return string allow|block|continue
+     * @return \SimpleSAML\Module\ratelimit\PreAuthStatusEnum
      */
-    public function allow(string $username, string $password): string;
+    public function allow(string $username, string $password): PreAuthStatusEnum;
 
     /**
      * Called after a successful authentication

--- a/src/Limiters/UsernameLimiter.php
+++ b/src/Limiters/UsernameLimiter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimpleSAML\Module\ratelimit\Limiters;
 
 class UsernameLimiter extends UserPassBaseLimiter

--- a/src/PreAuthStatusEnum.php
+++ b/src/PreAuthStatusEnum.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\Module\ratelimit;
+
+enum PreAuthStatusEnum
+{
+    case ALLOW;
+    case BLOCK;
+    case CONTINUE;
+}

--- a/tests/Utils/BaseLimitTest.php
+++ b/tests/Utils/BaseLimitTest.php
@@ -1,12 +1,16 @@
 <?php
 
-namespace SimpleSAML\Test\Module\ratelimit\Limiters;
+declare(strict_types=1);
 
-use CirrusIdentity\SSP\Test\InMemoryStore;
+namespace SimpleSAML\Test\Module\ratelimit\Utils;
+
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Configuration;
 use SimpleSAML\Module\ratelimit\Limiters\UserPassBaseLimiter;
 use SimpleSAML\Store\StoreFactory;
+use SimpleSAML\TestUtils\InMemoryStore;
+
+use function usleep;
 
 abstract class BaseLimitTest extends TestCase
 {

--- a/tests/Utils/BaseLimitTest.php
+++ b/tests/Utils/BaseLimitTest.php
@@ -7,6 +7,7 @@ namespace SimpleSAML\Test\Module\ratelimit\Utils;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Configuration;
 use SimpleSAML\Module\ratelimit\Limiters\UserPassBaseLimiter;
+use SimpleSAML\Module\ratelimit\PreAuthStatusEnum;
 use SimpleSAML\Store\StoreFactory;
 use SimpleSAML\TestUtils\InMemoryStore;
 
@@ -65,12 +66,12 @@ abstract class BaseLimitTest extends TestCase
         $password = 'Beer';
         for ($i = 1; $i <= 3; $i++) {
             // First 3 attempts should not be blocked
-            $this->assertEquals('continue', $limiter->allow($username, $password), "Attempt $i");
+            $this->assertEquals(PreAuthStatusEnum::CONTINUE, $limiter->allow($username, $password), "Attempt $i");
             $this->assertEquals($i, $limiter->postFailure($username, $password));
             $this->assertEquals($i, $this->getStoreValueFor($limiter->getRateLimitKey($username, $password)));
         }
         // After 3 failed attempts it should be blocked
-        $this->assertEquals('block', $limiter->allow($username, $password));
+        $this->assertEquals(PreAuthStatusEnum::BLOCK, $limiter->allow($username, $password));
 
         // Sleep until the next window, and counter should be reset
         usleep(4020000);
@@ -78,7 +79,7 @@ abstract class BaseLimitTest extends TestCase
             $this->getStoreValueFor($limiter->getRateLimitKey($username, $password)),
             'Value not expected in store'
         );
-        $this->assertEquals('continue', $limiter->allow($username, $password));
+        $this->assertEquals(PreAuthStatusEnum::CONTINUE, $limiter->allow($username, $password));
     }
 
     /**

--- a/tests/Utils/SampleLimiter.php
+++ b/tests/Utils/SampleLimiter.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\Test\Module\ratelimit\Utils;
+
+use SimpleSAML\Module\ratelimit\Limiters\UserPassBaseLimiter;
+
+class SampleLimiter extends UserPassBaseLimiter
+{
+    public function getRateLimitKey(string $username, string $password): string
+    {
+        return 'sample-' . $username[0];
+    }
+
+    public function determineWindowExpiration(int $time): int
+    {
+        return parent::determineWindowExpiration($time);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,39 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
 putenv('SIMPLESAMLPHP_CONFIG_DIR=' . __DIR__ . '/config');
 
-$projectRootDirectory = dirname(__DIR__);
-$projectConfigDirectory = $projectRootDirectory . '/tests/config';
-$modulePath = $projectRootDirectory . '/vendor/simplesamlphp/simplesamlphp/modules/ratelimit';
-$simplesamlphpConfig = $projectRootDirectory . '/vendor/simplesamlphp/simplesamlphp/config';
+$projectRoot = dirname(__DIR__);
+$projectConfigDirectory = $projectRoot . '/tests/config';
 
 /** @psalm-suppress UnresolvableInclude */
-require_once($projectRootDirectory . '/vendor/autoload.php');
+require_once($projectRoot . '/vendor/autoload.php');
 
-/**
- * Sets a link in the simplesamlphp vendor directory
- * @param string $target
- * @param string $link
- * @return void
- */
-function symlinkModulePathInVendorDirectory($target, $link)
-{
-    if (file_exists($link) === false) {
-        // If the link is invalid, remove it.
-        if (is_link($link)) {
-            unlink($link);
-        }
-        print "Linking '$link' to '$target'\n";
-        symlink($target, $link);
-    } else {
-        if (is_link($link) === false) {
-            // Looks like there is a directory here. Lets remove it and symlink in this one
-            print "Renaming pre-installed path and linking '$link' to '$target'\n";
-            rename($link, $link . '-preinstalled');
-            symlink($target, $link);
-        }
-    }
+// Symlink module into ssp vendor lib so that templates and urls can resolve correctly
+$linkPath = $projectRoot . '/vendor/simplesamlphp/simplesamlphp/modules/ratelimit';
+if (file_exists($linkPath) === false) {
+    echo "Linking '$linkPath' to '$projectRoot'\n";
+    symlink($projectRoot, $linkPath);
 }
 
-symlinkModulePathInVendorDirectory($projectRootDirectory, $modulePath);
-symlinkModulePathInVendorDirectory($projectConfigDirectory, $simplesamlphpConfig);
+// Symlink configuration into ssp vendor lib so that config can be resolved correctly
+$linkPath = $projectRoot . '/vendor/simplesamlphp/simplesamlphp/config';
+if (is_link($linkPath) === false) {
+    @rename($linkPath, $linkPath . '-preinstalled');
+    echo "Linking '$projectConfigDirectory' to '$linkPath'\n";
+    symlink($projectConfigDirectory, $linkPath);
+}

--- a/tests/config/config.php
+++ b/tests/config/config.php
@@ -17,7 +17,7 @@ $config = [
         'ratelimit' => true,
     ],
 
-    'store.type' => '\CirrusIdentity\SSP\Test\InMemoryStore',
+    'store.type' => '\SimpleSAML\TestUtils\InMemoryStore',
 
     'debug' => true,
     'logging.level' => Logger::DEBUG,

--- a/tests/src/Auth/Process/LoopDetectionTest.php
+++ b/tests/src/Auth/Process/LoopDetectionTest.php
@@ -1,19 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimpleSAML\Test\Module\ratelimit\Auth\Process;
 
-use CirrusIdentity\SSP\Test\Capture\RedirectException;
-use CirrusIdentity\SSP\Test\InMemoryStore;
-use CirrusIdentity\SSP\Test\MockHttp;
+use Exception;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use SimpleSAML\Auth\Source;
 use SimpleSAML\Module\core\Auth\UserPassBase;
 use SimpleSAML\Module\ratelimit\Auth\Process\LoopDetection;
-use SimpleSAML\Session;
-use SimpleSAML\TestUtils\ClearStateTestCase;
-use SimpleSAML\TestUtils\StateClearer;
-use SimpleSAML\Utils\HTTP;
+use SimpleSAML\{Session, Utils};
+use SimpleSAML\TestUtils\{ClearStateTestCase, InMemoryStore, StateClearer};
+
+use function strtotime;
 
 class LoopDetectionTest extends TestCase
 {
@@ -75,17 +75,16 @@ class LoopDetectionTest extends TestCase
         $expectedUrl = 'http://localhost/module.php/ratelimit/loop_detection';
 
         $emptyState = [];
-        $mockHttp = $this->createMock(HTTP::class);
+        $mockHttp = $this->createMock(Utils\HTTP::class);
         $mockHttp->method('redirectTrustedURL')
             ->with(
                 $expectedUrl,
                 $this->arrayHasKey('StateId')
             )
-            ->willThrowException(new \Exception('Redirect expected'));
+            ->willThrowException(new Exception('Redirect expected'));
 
         $source = new LoopDetection($config, null);
         $source->setHttp($mockHttp);
-
         $source->process($emptyState);
 
         $session->setData('ratelimit:loopDetection', 'Count', 11);

--- a/tests/src/Auth/Process/LoopDetectionTest.php
+++ b/tests/src/Auth/Process/LoopDetectionTest.php
@@ -61,6 +61,7 @@ class LoopDetectionTest extends TestCase
         //cli/phpunit sessions don't have session ids, but SessionHandlerStore needs a session id to save dirty state
         $class = new ReflectionClass(Session::class);
         $prop = $class->getProperty('sessionId');
+        /** @psalm-suppress UnusedMethodCall */
         $prop->setAccessible(true);
         $prop->setValue($session, 'mockedSessionId');
         $this->assertEquals('mockedSessionId', $session->getSessionId());

--- a/tests/src/Auth/Source/RateLimitUserPassTest.php
+++ b/tests/src/Auth/Source/RateLimitUserPassTest.php
@@ -1,17 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimpleSAML\Module\ratelimit\Auth\Source;
 
-use CirrusIdentity\SSP\Test\InMemoryStore;
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\Configuration;
-use SimpleSAML\Error;
+use SimpleSAML\{Configuration, Error};
 use SimpleSAML\Module\core\Auth\Source\AdminPassword;
-use SimpleSAML\Store\StoreFactory;
-use SimpleSAML\Store\StoreInterface;
+use SimpleSAML\Store\{StoreFactory, StoreInterface};
 use SimpleSAML\Test\Module\ratelimit\Limiters\ExceptionThrowingLimiter;
-use SimpleSAML\TestUtils\StateClearer;
-use SimpleSAML\Utils\HTTP;
+use SimpleSAML\TestUtils\{InMemoryStore, StateClearer};
 
 class RateLimitUserPassTest extends TestCase
 {

--- a/tests/src/Limiters/DeviceCookieLimiterTest.php
+++ b/tests/src/Limiters/DeviceCookieLimiterTest.php
@@ -1,14 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimpleSAML\Test\Module\ratelimit\Limiters;
 
-use CirrusIdentity\SSP\Test\InMemoryStore;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\Configuration;
+use SimpleSAML\{Configuration, Utils};
 use SimpleSAML\Module\ratelimit\Limiters\DeviceCookieLimiter;
-use SimpleSAML\Utils\HTTP;
+use SimpleSAML\TestUtils\InMemoryStore;
 
+#[CoversClass(DeviceCookieLimiter::class)]
 class DeviceCookieLimiterTest extends TestCase
 {
     /**
@@ -25,7 +28,7 @@ class DeviceCookieLimiterTest extends TestCase
     {
 
         // Stub the setCookie method
-        $this->mockHttp = $this->createMock(HTTP::class);
+        $this->mockHttp = $this->createMock(Utils\HTTP::class);
         $this->mockHttp->method('setCookie')
             ->with('deviceCookie', $this->callback(
                 function (?string $cookieValue) {
@@ -96,7 +99,6 @@ class DeviceCookieLimiterTest extends TestCase
         $limiter->postSuccess('me', 'pass');
         $deviceCookie = $this->getDeviceCookieFromMock();
         $_COOKIE['deviceCookie'] = $deviceCookie;
-
 
         $this->assertEquals(
             'allow',

--- a/tests/src/Limiters/DeviceCookieLimiterTest.php
+++ b/tests/src/Limiters/DeviceCookieLimiterTest.php
@@ -15,7 +15,7 @@ use SimpleSAML\TestUtils\InMemoryStore;
 class DeviceCookieLimiterTest extends TestCase
 {
     /**
-     * @var MockObject|HTTP
+     * @var \PHPUnit\Framework\MockObject\MockObject|\SimpleSAML\Utils\HTTP
      */
     private $mockHttp;
 

--- a/tests/src/Limiters/ExceptionThrowingLimiter.php
+++ b/tests/src/Limiters/ExceptionThrowingLimiter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimpleSAML\Test\Module\ratelimit\Limiters;
 
 use Exception;

--- a/tests/src/Limiters/ExceptionThrowingLimiter.php
+++ b/tests/src/Limiters/ExceptionThrowingLimiter.php
@@ -6,6 +6,7 @@ namespace SimpleSAML\Test\Module\ratelimit\Limiters;
 
 use Exception;
 use SimpleSAML\Module\ratelimit\Limiters\UserPassLimiter;
+use SimpleSAML\Module\ratelimit\PreAuthStatusEnum;
 
 class ExceptionThrowingLimiter implements UserPassLimiter
 {
@@ -13,10 +14,10 @@ class ExceptionThrowingLimiter implements UserPassLimiter
      * Called prior to verifying the credentials to determine if the attempt is allowed.
      * @param string $username The username to check
      * @param string $password The password to check
-     * @return string allow|block|continue
+     * @return \SimpleSAML\Module\ratelimit\PreAuthStatusEnum
      * @throws \Exception always thrown
      */
-    public function allow(string $username, string $password): string
+    public function allow(string $username, string $password): PreAuthStatusEnum
     {
         throw new Exception('Boom!');
     }

--- a/tests/src/Limiters/IpLimiterTest.php
+++ b/tests/src/Limiters/IpLimiterTest.php
@@ -7,6 +7,7 @@ namespace SimpleSAML\Test\Module\ratelimit\Limiters;
 use PHPUnit\Framework\Attributes\{CoversClass, DataProvider};
 use SimpleSAML\Configuration;
 use SimpleSAML\Module\ratelimit\Limiters\{IpLimiter, UserPassBaseLimiter};
+use SimpleSAML\Module\ratelimit\PreAuthStatusEnum;
 use SimpleSAML\Test\Module\ratelimit\Utils\BaseLimitTest;
 
 #[CoversClass(IpLimiter::class)]
@@ -41,7 +42,7 @@ class IpLimiterTest extends BaseLimitTest
 
         $limiter = $this->getLimiter($config);
         $this->assertEquals($ignoreExpected ? 0 : 1, $limiter->postFailure('u', 'p'));
-        $this->assertEquals($ignoreExpected ? 'continue' : 'block', $limiter->allow('u', 'p'));
+        $this->assertEquals($ignoreExpected ? PreAuthStatusEnum::CONTINUE : PreAuthStatusEnum::BLOCK, $limiter->allow('u', 'p'));
     }
 
     public static function ipWhitelistProvider(): array

--- a/tests/src/Limiters/IpLimiterTest.php
+++ b/tests/src/Limiters/IpLimiterTest.php
@@ -1,11 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimpleSAML\Test\Module\ratelimit\Limiters;
 
+use PHPUnit\Framework\Attributes\{CoversClass, DataProvider};
 use SimpleSAML\Configuration;
-use SimpleSAML\Module\ratelimit\Limiters\IpLimiter;
-use SimpleSAML\Module\ratelimit\Limiters\UserPassBaseLimiter;
+use SimpleSAML\Module\ratelimit\Limiters\{IpLimiter, UserPassBaseLimiter};
+use SimpleSAML\Test\Module\ratelimit\Utils\BaseLimitTest;
 
+#[CoversClass(IpLimiter::class)]
 class IpLimiterTest extends BaseLimitTest
 {
     protected function setUp(): void
@@ -19,10 +23,10 @@ class IpLimiterTest extends BaseLimitTest
     }
 
     /**
-     * @dataProvider ipWhitelistProvider
      * @param string $ip The user's ip address
      * @param bool $ignoreExpected If this IP should be ignored
      */
+    #[DataProvider('ipWhitelistProvider')]
     public function testIpWhitelist(string $ip, bool $ignoreExpected): void
     {
         $config = [
@@ -40,7 +44,7 @@ class IpLimiterTest extends BaseLimitTest
         $this->assertEquals($ignoreExpected ? 'continue' : 'block', $limiter->allow('u', 'p'));
     }
 
-    public function ipWhitelistProvider(): array
+    public static function ipWhitelistProvider(): array
     {
         return [
             ['12.3.7.12', false],

--- a/tests/src/Limiters/UserPassBaseLimiterTest.php
+++ b/tests/src/Limiters/UserPassBaseLimiterTest.php
@@ -1,10 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimpleSAML\Test\Module\ratelimit\Limiters;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use SimpleSAML\Configuration;
 use SimpleSAML\Module\ratelimit\Limiters\UserPassBaseLimiter;
+use SimpleSAML\Test\Module\ratelimit\Utils\BaseLimitTest;
+use SimpleSAML\Test\Module\ratelimit\Utils\SampleLimiter;
 
+#[CoversClass(UserPassBaseLimiter::class)]
 class UserPassBaseLimiterTest extends BaseLimitTest
 {
     protected function getLimiter(array $config): UserPassBaseLimiter
@@ -21,18 +27,5 @@ class UserPassBaseLimiterTest extends BaseLimitTest
         $key1 = $limiter->getRateLimitKey('1', 'p');
         $key2 = $limiter->getRateLimitKey('2', 'p');
         $this->assertNotEquals($key1, $key2, 'keys should vary');
-    }
-}
-// phpcs:ignore
-class SampleLimiter extends UserPassBaseLimiter
-{
-    public function getRateLimitKey(string $username, string $password): string
-    {
-        return 'sample-' . $username[0];
-    }
-
-    public function determineWindowExpiration(int $time): int
-    {
-        return parent::determineWindowExpiration($time);
     }
 }

--- a/tests/src/Limiters/UsernameLimiterTest.php
+++ b/tests/src/Limiters/UsernameLimiterTest.php
@@ -1,11 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimpleSAML\Test\Module\ratelimit\Limiters;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use SimpleSAML\Configuration;
-use SimpleSAML\Module\ratelimit\Limiters\UsernameLimiter;
-use SimpleSAML\Module\ratelimit\Limiters\UserPassBaseLimiter;
+use SimpleSAML\Module\ratelimit\Limiters\{UsernameLimiter, UserPassBaseLimiter};
+use SimpleSAML\Test\Module\ratelimit\Utils\BaseLimitTest;
 
+#[CoversClass(UserNameLimiter::class)]
 class UsernameLimiterTest extends BaseLimitTest
 {
     /**

--- a/tools/composer-require-checker.json
+++ b/tools/composer-require-checker.json
@@ -1,0 +1,4 @@
+{
+  "symbol-whitelist": [
+  ]
+}


### PR DESCRIPTION
- Removed legacy `default-enable` file
- Updated .gitignore file to exclude phpunit-results from the repository
- Using InMemoryStore from SSP's test-framework (I ported it from `cirrusiddentity/simplesamlphp-test-utils`)
- Migrated PHPunit config file
- Added `declare(strict_types=1)` to every php-file in the repository
- Added use-statements
- Moved a few unittest helper-classes to `tests/Utils`
- Migrated PHPunit annotations to attributes
- Replaced status-strings by enum

Please ignore the failing test. It's a bug in SimpleSAMLphp that has been fixed (yet not released)